### PR TITLE
add comment to config for custom_plate_path

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,6 +10,7 @@ output_dir: "output"
 clear_cache: false
 print_available_models: false
 
+# if specified, the plate at this path will be used to generate the ADT
 custom_plate_path: ""
 
 page_range:


### PR DESCRIPTION
This help explain that the plate can be overridden by specifying one to use instead of the generated one.