### PR TITLE
avoid run failure if a page has no page_id

### DIFF
--- a/templates/nav.html
+++ b/templates/nav.html
@@ -7,7 +7,7 @@
     <ol class="nav__list overflow-y-auto h-[calc(100vh-10rem)] text-base pr-2" data-id="nav-list" id="nav__list">
         {% for webpage in webpages %}
         <li class="nav__list-item">
-            <a class="nav__list-link" data-text-id="{{ webpage.text_id }}" href="{{ webpage.section_id }}.html">{% with text=texts[webpage.text_id] %}{{ text.text }}{% endwith %}</a>
+      <a class="nav__list-link" data-text-id="{{ webpage.text_id | default('') }}" href="{{ webpage.section_id }}.html"> {% if webpage.text_id %}{% with text=texts[webpage.text_id] %}{{ text.text | default('') }}{% endwith %}{% endif %}</a>
         </li>
         {% endfor %}
     </ol>


### PR DESCRIPTION
allow pages that lack `page_id` by including a default value ('') in the jinja template, and only trying to access text if some page texts exist

this avoids run failure for the case described in this comment https://github.com/unicef/adt-press/issues/46#issuecomment-3167358035