### PR TITLE
Update the update action to reflect the different versions in the ADT-output-tests repo

### DIFF
--- a/.github/workflows/update-output-test.yml
+++ b/.github/workflows/update-output-test.yml
@@ -41,8 +41,11 @@ jobs:
           timestamp=$(date +%Y%m%d)
           for pdf in assets/*.pdf; do
             label=$(basename "$pdf" .pdf)
-            mkdir -p ADT-output-tests/$label/$timestamp
-            cp -r output/$label/* ADT-output-tests/$label/$timestamp/
+            if compgen -G "output/$label/*" > /dev/null; then
+              cp -r output/$label/* ADT-output-tests/$label/$timestamp/
+            else
+              echo "Warning: No output files found for label '$label' in output/$label/"
+            fi
             cp "$pdf" ADT-output-tests/pdfs/
           done
 


### PR DESCRIPTION
Added the creation of folder with the current date stamp so we can see the different versions.