### PR TITLE
The docker build process now ignores the output folder. 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,5 @@ __pycache__/
 .git
 .gitignore
 tests/
+output/
 # Removed exclusion of README.md


### PR DESCRIPTION
This PR fixes a small issue that preventing to rebuild the container while having run the adt-press and having something on the output folder.

When the output folder is ignored in the build of the container, an error with a node_module folder is not present. This enables the container to build successfully.