### PR TITLE
Edit matching in text_extraction.py to handle repeated text and improve match rate.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,15 +17,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Format code 
+      - name: Check code
         uses: astral-sh/ruff-action@v3
         with:
-          args: "format --check --diff"
+          args: "check --fix"
 
       - name: Format code 
         uses: astral-sh/ruff-action@v3
         with:
-          args: "check"
+          args: "format"
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/adt_eval/text_extraction.py
+++ b/adt_eval/text_extraction.py
@@ -1,9 +1,9 @@
 """Text extraction evaluation implementation.
-    
+
 Some notes on the scoring of matches:
 - The LabelStudio text_type dataset sometimes had errors in the text_transcript that were later corrected. Thus, in this script, we correct some of these errors as well (for example, removing double spaces).
 - Mismatches are often introduced by mismatched directional quotations, e.g. ’,”,‘,“. These are replaced by non-directional quotations in both the LLM output and the Gold Standard.
-- The match strategy implemented is a greedy one. 
+- The match strategy implemented is a greedy one.
     - For each line in the LLM output, a list of labels is created (where each item in the list is the text type corresponding to one repetition of the line in the LLM output).
     - For each line in the Gold Standard transcript, we seek a match and, if the line matches, one text type item is 'used up' from the list.
 """
@@ -53,12 +53,11 @@ class TextExtractionEvaluator(BaseEvaluator):
         actual_type_by_text = {}
         for group in page_texts.groups:
             for text_item in group.texts:
-
                 # Some mild cleaning on the text content to match the Gold Standard
-                text_item.text=text_item.text.replace("’", "'")
-                text_item.text=text_item.text.replace("”", '"')
-                text_item.text=text_item.text.replace("‘", "'")
-                text_item.text=text_item.text.replace("“", '"')
+                text_item.text = text_item.text.replace("’", "'")
+                text_item.text = text_item.text.replace("”", '"')
+                text_item.text = text_item.text.replace("‘", "'")
+                text_item.text = text_item.text.replace("“", '"')
 
                 if text_item.text not in actual_type_by_text.keys():
                     # If text does not yet appear in dictionary, insert as a 1-item list
@@ -67,7 +66,6 @@ class TextExtractionEvaluator(BaseEvaluator):
                     # If it exists, add to list
                     actual_type_by_text[text_item.text].append(text_item.text_type.value)
 
-
         # Compare with truth annotations
         matches = []
         for tt in truth:
@@ -75,21 +73,21 @@ class TextExtractionEvaluator(BaseEvaluator):
             text_type = tt["value"]["taxonomy"][0][0]
 
             # Some mild cleaning on the text content to match the Gold Standard
-            text_content=text_content.replace("\/","/")
-            text_content=text_content.replace("\\n","\n")
-            text_content=text_content.replace("  "," ")
-            text_content=text_content.replace("’", "'")
-            text_content=text_content.replace("”", '"')
-            text_content=text_content.replace("‘", "'")
-            text_content=text_content.replace("“", '"')
-            text_content=text_content.replace("\xad", "")
+            text_content = text_content.replace("\/", "/")
+            text_content = text_content.replace("\\n", "\n")
+            text_content = text_content.replace("  ", " ")
+            text_content = text_content.replace("’", "'")
+            text_content = text_content.replace("”", '"')
+            text_content = text_content.replace("‘", "'")
+            text_content = text_content.replace("“", '"')
+            text_content = text_content.replace("\xad", "")
 
             # Implement match between ground truth TT and actual LLM result, greedily taking the first text type in the list
-            if (text_content in actual_type_by_text):
+            if text_content in actual_type_by_text:
                 actual_type = actual_type_by_text[text_content].pop(0)
 
                 # Remove key if list is empty
-                if (len(actual_type_by_text[text_content]) == 0):
+                if len(actual_type_by_text[text_content]) == 0:
                     del actual_type_by_text[text_content]
             else:
                 actual_type = None


### PR DESCRIPTION
- Allows for multiple occurrences of a line, each with a different text type.  This makes it possible for a line to be repeated and still be assigned a text type (rather than `None')
- Do some light string cleaning on the text in Gold Standard datasets and LLM output to improve the match rate -- remove excess spaces, replace directional quotation marks for neutral ones (", '), etc.

The string cleaning should more elegantly be given its own function rather than implemented line by line in this file > I have left left for future work as additional cleaning still needs to be added.