### PR TITLE
Disable notepad popup and button on adt output

### DIFF
--- a/assets/web/assets/base.js
+++ b/assets/web/assets/base.js
@@ -453,9 +453,15 @@ function applyFeatureFlags(features) {
       
       if (notepadButton) {
         notepadButton.classList.toggle('hidden', !enabled);
+        notepadButton.setAttribute('aria-expanded', 'false');
       }
       if (notepadContent) {
-        notepadContent.classList.toggle('hidden', !enabled);
+        notepadContent.classList.add('hidden');
+        if (!enabled) {
+          notepadContent.setAttribute('aria-hidden', 'true');
+        } else {
+          notepadContent.removeAttribute('aria-hidden');
+        }
       }
     } else if (feature === 'showAutoHideButton') {
       // Hide/show the auto-hide menu toggle button

--- a/assets/web/assets/config.json
+++ b/assets/web/assets/config.json
@@ -16,7 +16,7 @@
   "showNavigationControls": true,
   "showTutorial": true,
     "describeImages": true,
-    "notepad": true,
+    "notepad": false,
     "showAutoHideButton": true,
     "characterDisplay": false,
     "highlight": false


### PR DESCRIPTION
**Problem**
The notepad popup and button were being enabled and displayed by default on page load for adt generation. The resulted in the notepad popup displaying on every page open

**Solution**
Stop the notepad popup bubble from loading opened on subsequent pages. Hide and disable the notepad button by default on all adt generation types.