### PR TITLE
Apply eli5 feature flag to config to hide/show

### DIFF
--- a/adt_press/nodes/web_nodes.py
+++ b/adt_press/nodes/web_nodes.py
@@ -207,7 +207,7 @@ def package_adt_web(
         languages=list(plate_translations.keys()),
         default_language=default_language,
         strategy_config=strategy_config,
-        output_subdir="webpub",
+        output_subdir="adt",
     )
 
     build_web_assets(run_output_dir_config, list(plate_translations.keys()))

--- a/assets/web/assets/base.js
+++ b/assets/web/assets/base.js
@@ -493,24 +493,6 @@ function applyFeatureFlags(features) {
       if (characterProfileRow) {
         characterProfileRow.classList.toggle('hidden', !enabled);
       }
-    } else if (feature === 'eli5') {
-      // Hide/show the Explain Me toggle in sidebar
-      const eli5Container = document.getElementById('eli5-container');
-      if (eli5Container) {
-        eli5Container.classList.toggle('hidden', !enabled);
-      }
-      
-      // Hide/show the Explain Me floating button
-      const explainMeButton = document.getElementById('explain-me-button');
-      if (explainMeButton) {
-        explainMeButton.classList.toggle('hidden', !enabled);
-      }
-      
-      // Hide/show the Explain Me content popup
-      const eli5Content = document.getElementById('eli5-content');
-      if (eli5Content) {
-        eli5Content.classList.toggle('hidden', !enabled);
-      }
     } else {
       // Find the toggle element for other features
       const toggleElement = elementCache.get(`toggle-${kebabFeature}`);

--- a/assets/web/assets/config.json
+++ b/assets/web/assets/config.json
@@ -8,7 +8,7 @@
   },
   "features": {
     "signLanguage": false,
-    "easyRead": true,
+    "easyRead": false,
     "glossary": false,
     "eli5": false,
     "readAloud": true,
@@ -16,7 +16,7 @@
   "showNavigationControls": true,
   "showTutorial": true,
     "describeImages": true,
-    "notepad": true,
+    "notepad": false,
     "showAutoHideButton": true,
     "characterDisplay": false,
     "highlight": false


### PR DESCRIPTION
**Problem**
The eli5 toggle and popup were not being hidden if the explanations were not being generated.

**Solution**
Added the eli5 feature flag to the config that is generated after generating an adt. The eli5 feature is now hidden if explanations are not added.