### PR TITLE
add missing fill_in_the_blank text type

### DIFF
--- a/adt_press/models/text.py
+++ b/adt_press/models/text.py
@@ -23,6 +23,7 @@ class TextType(str, enum.Enum):
     instruction_text = "instruction_text"
     activity_number = "activity_number"
     activity_option = "activity_option"
+    fill_in_the_blank = "fill_in_the_blank"
     activity_input_placeholder_text = "activity_input_placeholder_text"
     image_label = "image_label"
     image_caption = "image_caption"


### PR DESCRIPTION
Prompt includes a text type of `fill_in_the_blank` but is missing from the `TextType` model 
https://github.com/unicef/adt-press/blob/3aaad8e7693fc49b2e688c1191fb28c1b7319709/prompts/text_extraction_groups.jinja2#L25