### PR TITLE
Removes the max retries from the activity-generation related calls

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -258,69 +258,56 @@ prompts:
   activity_sorting:
     model: default
     template_path: prompts/activities/sorting.jinja2
-    max_retries: 0
     
   activity_matching:
     model: default
     template_path: prompts/activities/matching.jinja2
-    max_retries: 0
     
   activity_fill_in_a_table:
     model: default
     template_path: prompts/activities/fill_in_a_table.jinja2
-    max_retries: 0
     
   activity_true_false:
     model: default
     template_path: prompts/activities/true_false.jinja2
-    max_retries: 0
     
   activity_open_ended_answer:
     model: default
     template_path: prompts/activities/open_ended_answer.jinja2
-    max_retries: 0
     
   activity_fill_in_the_blank:
     model: default
     template_path: prompts/activities/fill_in_the_blank.jinja2
-    max_retries: 0
     
   activity_multiple_choice:
     model: default
     template_path: prompts/activities/multiple_choice.jinja2
-    max_retries: 0
 
   # Activity-specific answer generation prompts
     
   activity_sorting_answers:
     model: default
     template_path: prompts/activities/answers/sorting.jinja2
-    max_retries: 0
     
   activity_matching_answers:
     model: default
     template_path: prompts/activities/answers/matching.jinja2
-    max_retries: 0
     
   activity_true_false_answers:
     model: default
     template_path: prompts/activities/answers/true_false.jinja2
-    max_retries: 0
     
   activity_fill_in_the_blank_answers:
     model: default
     template_path: prompts/activities/answers/fill_in_the_blank.jinja2
-    max_retries: 0
     
   activity_fill_in_a_table_answers:
     model: default
     template_path: prompts/activities/answers/fill_in_a_table.jinja2
-    max_retries: 0
     
   activity_multiple_choice_answers:
     model: default
     template_path: prompts/activities/answers/multiple_choice.jinja2
-    max_retries: 0
 
   speech_generation:
     model: gpt-4o-mini-tts


### PR DESCRIPTION
This small PR removes the `max_retries` from the `config.yaml`.

This enables to retry the call if the response fails due to the pydantic validator.