### PR TITLE
feat(eval): add text translation task eval

### DIFF
--- a/adt-eval.py
+++ b/adt-eval.py
@@ -26,12 +26,14 @@ from omegaconf import OmegaConf
 
 os.environ["DISABLE_MLFLOW_LITELLM_AUTOLOG"] = "1"  # Disable autologging
 from adt_eval.text_type import TextTypeEvaluator
+from adt_eval.text_translation import TextTranslationEvaluator
 from adt_press.models.config import TemplateConfig
 from adt_press.utils.html import render_template
 
 # Registry of available evaluators
 EVALUATORS = {
     "text_type": TextTypeEvaluator,
+    "text_translation": TextTranslationEvaluator,
 }
 
 

--- a/adt-eval.py
+++ b/adt-eval.py
@@ -25,8 +25,8 @@ from dotenv import load_dotenv
 from omegaconf import OmegaConf
 
 os.environ["DISABLE_MLFLOW_LITELLM_AUTOLOG"] = "1"  # Disable autologging
-from adt_eval.text_type import TextTypeEvaluator
 from adt_eval.text_translation import TextTranslationEvaluator
+from adt_eval.text_type import TextTypeEvaluator
 from adt_press.models.config import TemplateConfig
 from adt_press.utils.html import render_template
 

--- a/adt_eval/mlflow_base.py
+++ b/adt_eval/mlflow_base.py
@@ -156,7 +156,7 @@ class MLflowEvaluatorBase(BaseEvaluator):
     async def run(self):
         """Main evaluation workflow with MLflow run tracking."""
         self.configure_mlflow()
-        
+
         run_name = self.get_run_name()
         nested = mlflow.active_run() is not None
         self._loop_runner = AsyncLoopRunner()

--- a/adt_eval/mlflow_base.py
+++ b/adt_eval/mlflow_base.py
@@ -13,7 +13,6 @@ import mlflow
 
 from adt_eval.base import BaseEvaluator
 
-
 class AsyncLoopRunner:
     """Run coroutines on a long-lived event loop in a background thread."""
 
@@ -89,10 +88,17 @@ class MLflowEvaluatorBase(BaseEvaluator):
         eval_cfg = self.global_config.get("eval", {})
         return eval_cfg.get("mlflow", {}) if isinstance(eval_cfg, dict) else {}
 
+    def _get_experiment_name(self) -> Optional[str]:
+        task_cfg = self.task_config.get("experiments_config", {})
+        task_experiment = task_cfg.get("experiment_name") if isinstance(task_cfg, dict) else None
+        if task_experiment:
+            return task_experiment
+        return self._get_mlflow_config().get("experiment_name")
+
     def configure_mlflow(self) -> None:
         mlflow_cfg = self._get_mlflow_config()
         tracking_uri = mlflow_cfg.get("tracking_uri")
-        experiment_name = mlflow_cfg.get("experiment_name")
+        experiment_name = self._get_experiment_name()
 
         mlflow.autolog(disable=True)
 
@@ -149,6 +155,7 @@ class MLflowEvaluatorBase(BaseEvaluator):
     async def run(self):
         """Main evaluation workflow with MLflow run tracking."""
         self.configure_mlflow()
+        
         run_name = self.get_run_name()
         nested = mlflow.active_run() is not None
         self._loop_runner = AsyncLoopRunner()
@@ -171,6 +178,7 @@ class MLflowEvaluatorBase(BaseEvaluator):
                 if results and metrics:
                     self.generate_report(results, metrics)
                 return results, metrics
+
         finally:
             self._loop_runner.close()
             self._loop_runner = None

--- a/adt_eval/mlflow_base.py
+++ b/adt_eval/mlflow_base.py
@@ -13,6 +13,7 @@ import mlflow
 
 from adt_eval.base import BaseEvaluator
 
+
 class AsyncLoopRunner:
     """Run coroutines on a long-lived event loop in a background thread."""
 

--- a/adt_eval/text_translation.py
+++ b/adt_eval/text_translation.py
@@ -1,0 +1,396 @@
+"""Text type evaluation implementation.
+
+Some notes on the scoring of matches:
+- The LabelStudio text_type dataset sometimes had errors in the text_transcript that were later corrected. Thus, in this script, we correct some of these errors as well (for example, removing double spaces).
+- Mismatches are often introduced by mismatched directional quotations, e.g. ’,”,‘,“. These are replaced by non-directional quotations in both the LLM output and the Gold Standard.
+- The match strategy implemented is a greedy one.
+    - For each line in the LLM output, a list of labels is created (where each item in the list is the text type corresponding to one repetition of the line in the LLM output).
+    - For each line in the Gold Standard transcript, we seek a match and, if the line matches, one text type item is 'used up' from the list.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from mlflow.entities import Feedback
+from mlflow.genai import scorer
+from litellm import completion
+
+from adt_eval.mlflow_base import MLflowEvaluatorBase
+from adt_eval.utils.transcript_cleaner import normalize_transcript, standardize_transcript
+from adt_press.utils.languages import Language
+from adt_press.llm.text_translation import get_text_translation
+from adt_press.models.config import TextGroupType, TextType
+from adt_press.models.pdf import Page
+from adt_press.models.text import PageTextGroups, Text, TextGroup
+from adt_press.models.eval.text_translation import TranslationEvalOutputs
+from adt_press.utils.languages import Language
+from adt_eval.utils.file import encode_image_to_base64
+
+TRANSLATION_SCORER_SYSTEM_PROMPT = """
+You are an expert multilingual translation evaluator specializing in children’s educational textbooks.
+You evaluate translations with a strict editorial standard suitable for K–12 instructional materials.
+
+Your task is NOT to translate. Your task is to STRICTLY JUDGE whether a translation is ACCEPTABLE or NOT ACCEPTABLE.
+
+You will be provided with:
+- input_language: the source language code.
+- input_text: the exact source text extracted from the textbook.
+- output_language: the target language code.
+- output_text: the model-generated translation.
+- page_image: an image of the textbook page (base64).
+
+Use the image ONLY to understand:
+- the role of the text (heading, label, instruction, paragraph, caption)
+- the subject matter (math, science, literacy, etc.)
+- the layout context (placement on page)
+
+If the image is unclear or partially visible, do not assume or invent anything.
+Your decision must be based primarily on input_text and output_text.
+
+----------------------------------------------------
+DEFINITION OF “ACCEPTABLE TRANSLATION”
+----------------------------------------------------
+A translation is ACCEPTABLE only if ALL conditions below are fully satisfied.
+If you are unsure whether an error is minor or major, treat it as major.
+
+### 1. ADEQUACY (meaning preservation — strict)
+- The translation preserves the complete meaning.
+- No omissions, distortions, additions, or reinterpretations.
+- All quantities, names, terminology, and logical relationships are correctly preserved.
+- No ambiguity introduced.
+
+### 2. FLUENCY & NATURALNESS (strict editorial standard)
+The target-language text must:
+- Be grammatically correct.
+- Use natural, idiomatic phrasing for children’s educational materials.
+- Sound like authentic textbook language for that language and grade level.
+- Avoid literal, machine-like, or awkward phrasing even if meaning is understandable.
+- Use appropriate stylistic form for headings, labels, and instructions.
+
+For ALL languages:
+If the translation sounds unnatural, unidiomatic, or does not resemble real textbook phrasing,
+→ NOT ACCEPTABLE.
+
+### 3. TERMINOLOGY & SUBJECT ACCURACY
+- Terminology must match grade-level norms for the target language.
+- Technical and academic concepts must remain correct.
+- No mistranslation that could cause misunderstanding of a concept.
+
+### 4. CONTEXTUAL APPROPRIATENESS (image-based)
+- Headings must read like headings.
+- Labels must read like labels.
+- Instructions must read like instructions.
+- The style and tone must fit children’s textbooks.
+
+----------------------------------------------------
+ADDITIONAL LANGUAGE-PAIR GUIDELINES (ENGLISH → SPANISH)
+----------------------------------------------------
+If input_language = "en" and output_language = "es", apply the following STRICT rules:
+
+### Spanish Textbook Fluency Rules
+Translations resembling any of the following patterns are NOT ACCEPTABLE:
+- Literal English calques (e.g., “NÚMEROS IMPACTANTES”, “PROBLEMAS DE HISTORIAS SOBRE...”)
+- Machine-like verb constructions
+- Unnatural noun constructions
+- Awkward or non-standard academic phrasing
+- Any phrasing not typically found in real Spanish K–12 textbooks
+
+The translation must sound like a native-authored Spanish textbook, not a direct conversion.
+
+### Non-acceptable Spanish Indicators
+If the Spanish includes unnatural literal phrasing, incorrect register, awkward expressions, or machine-like style,
+treat as major errors, even if meaning is technically understandable.
+
+----------------------------------------------------
+ERROR SEVERITY (STRICT INTERPRETATION)
+----------------------------------------------------
+
+### MAJOR ERRORS (→ ALWAYS NOT ACCEPTABLE)
+- Any mistranslation or incorrect meaning.
+- Any omitted or added content.
+- Incorrect or misleading terminology.
+- Any unnatural, awkward, or machine-like phrasing.
+- Any grammatical error.
+- Any mismatch with the text’s function (heading/label/etc.).
+- Any stylistic issue that would not pass editorial review.
+
+### MINOR ERRORS (rare, acceptable only if meaning + fluency + context are perfect)
+- Very small stylistic differences that do NOT affect idiomaticity, clarity, tone, or naturalness.
+- Harmless formatting differences.
+
+If unsure, classify the issue as major.
+
+----------------------------------------------------
+EVALUATION PROCESS (INTERNAL — DO NOT OUTPUT)
+----------------------------------------------------
+1. Assess adequacy.
+2. Assess fluency & naturalness with strict textbook standards.
+3. Assess terminology accuracy.
+4. Assess contextual appropriateness using the image.
+5. Apply strict error classification.
+6. Decide ACCEPTABLE vs NOT ACCEPTABLE.
+
+Do NOT reveal chain-of-thought.
+
+----------------------------------------------------
+OUTPUT FORMAT
+----------------------------------------------------
+Return ONLY the following JSON object:
+
+- is_translation_acceptable: boolean
+- rationale: short English explanation (1–3 sentences) summarizing the key reasons.
+
+Do NOT output anything else.
+"""
+
+
+@scorer
+def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -> Feedback:
+
+    page_text_list = inputs.get("page_text_list", [])
+    source_language = inputs.get("base_language", "en")
+    target_language = inputs.get("target_language", "es")
+    page_text_translations = outputs.get("page_text_translations", [])
+
+    if isinstance(source_language, Language):
+        source_language = source_language.model_dump()
+
+    if isinstance(target_language, Language):
+        target_language = target_language.model_dump()
+
+    #get image  
+    image_path = inputs.get("image_path", "")
+    image_b64 = encode_image_to_base64(image_path)
+
+    #build eval_page_text_translations
+    eval_page_text_translations = []
+    for i, page_text_translation in enumerate(page_text_translations):
+        _, _, base_text = page_text_list[i]
+        translation_entry = {
+            "text_id": page_text_translation["text_id"],
+            "base_text": base_text,
+            "translation": page_text_translation["text"],
+        }
+        eval_page_text_translations.append(translation_entry)
+
+
+    if image_b64:
+        user_content = [
+            {
+                "type": "text",
+                "text": (
+                    "Evaluate whether the following Translation is ACCEPTABLE, "
+                    "using the criteria in the system prompt.\n\n"
+                    f"source_language: {source_language}\n"
+                    f"target_language: {target_language}\n"
+                    f"List of translations :\n\n{eval_page_text_translations}\n\n"
+                    "Below is the textbook page image in base64 format. "
+                    "Use it only to understand the context and how the text is used:\n"
+                ),
+            },
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{image_b64}"
+                },
+            },
+        ]
+    else:
+        user_content = (
+            "Evaluate whether the following Translation is ACCEPTABLE, "
+            "using the criteria in the system prompt.\n\n"
+            f"source_language: {source_language}\n"
+            f"target_language: {target_language}\n"
+            f"List of translations :\n\n{eval_page_text_translations}\n\n"
+        )
+
+    messages = [
+        {"role": "system", "content": TRANSLATION_SCORER_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    eval_output = completion(
+        model="gpt-5",
+        messages=messages,
+        response_format=TranslationEvalOutputs,
+    )
+
+    # Align with how you're handling other response_format=Pydantic calls
+    msg = eval_output.choices[0].message
+    translation_eval = TranslationEvalOutputs.model_validate_json(msg.content)
+    translation_output = translation_eval.model_dump()['outputs']
+
+    #calculating the translation eval summary
+    summary_of_translations = [translation['is_translation_acceptable'] for translation in translation_output]
+    summary_of_failed_translations = [
+        {"text_id": translation["text_id"], "rationale": translation["rationale"]}
+        for translation in translation_output
+        if not translation["is_translation_acceptable"]
+    ]
+
+    
+    #calculating the translation eval metric
+    metric= round(sum(summary_of_translations) / len(summary_of_translations), 2)
+    
+    #calculating the translation eval rationale
+    if summary_of_failed_translations:
+        combined_rationale = "The folowing translations are not acceptable:\n\n"
+        for entry in summary_of_failed_translations:
+            combined_rationale += f"- text_id: {entry['text_id']}\n  reason: {entry['rationale']}\n\n" 
+    else:
+        combined_rationale = "All translations are acceptable."
+    
+    return Feedback(
+        name="text_translation_score",
+        value=metric,
+        rationale=combined_rationale,
+    )
+
+
+class TextTranslationEvaluator(MLflowEvaluatorBase):
+    """Evaluator for text translation accuracy."""
+
+    def __init__(self, global_config: Dict[str, Any], task_config: Dict[str, Any], output_dir: Path):
+        super().__init__(global_config, task_config, output_dir)
+
+        self.base_language = Language.from_code(global_config.get("input_language", "en"))
+        self.target_language = Language.from_code("es")
+
+    def build_page_texts_from_log(self, fpath: Path) -> PageTextGroups:
+        """Build PageTextGroups object from logged JSON file, as an alternative to LLM call."""
+        with open(fpath, "r", encoding="utf8") as f:
+            page_texts = json.load(f)
+            output = page_texts["output"]
+
+        page_text_groups = []
+        for g in output["groups"]:
+            page_texts = []
+            for t in g["texts"]:
+                page_text = Text(text_id=t["text_id"], text=t["text"], text_type=t["text_type"])
+                page_texts.append(page_text)
+            page_text_group = TextGroup(group_id=g["group_id"], group_type=g["group_type"], texts=page_texts)
+            page_text_groups.append(page_text_group)
+        page_texts = PageTextGroups(page_id=output["page_id"], groups=page_text_groups, reasoning=output["reasoning"])
+
+        return page_texts
+
+    async def process_case(self, step: int, test_case: Dict[str, Any], use_cached_llm_results) -> Dict[str, Any]:
+        """Legacy path: TextTypeEvaluator runs via mlflow.genai.evaluate."""
+        raise NotImplementedError("TextTypeEvaluator uses mlflow.genai.evaluate.")
+
+    def build_eval_dataset(self, cases: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        for step, tc in enumerate(cases):
+            test = tc["data"]
+            latest_annotation = max(tc["annotations"], key=lambda x: x["updated_at"])
+            truth = [i["result"] for i in tc["annotations"] if i["id"] == latest_annotation["id"]][0]
+            page_image_path = self.download_azure_image(
+                test["page_image"],
+                f"text_extraction_page_{tc['id']}.png",
+            )
+            
+            page_text_list = [
+                (
+                    t["id"],
+                    t["value"]["taxonomy"][0][0] if t["value"].get("taxonomy") else "",
+                    t["value"]["text"]
+                )
+                for t in truth
+            ]
+
+            records.append(
+                {
+                    "inputs": {
+                        "case_id": tc["id"],
+                        "step": step,
+                        "page_text_all": test["page_text_all"],
+                        "page_image_path": str(page_image_path),
+                        "book_title": test["book_name"],
+                        "page_number": test["page_id"],
+                        "label_studio_project": tc["project"],
+                        "page_text_list": page_text_list,
+                        "base_language": self.base_language,
+                        "target_language": self.target_language,
+                    },
+                    "expectations": {},
+                }
+            )
+
+        
+        return records
+
+    def predict_fn(self, **inputs: Any) -> Dict[str, Any]:
+        page_text_all = inputs["page_text_all"]
+        page_image_path = inputs["page_image_path"]
+        page_text_list = inputs["page_text_list"]
+        
+        page_text_translations = []
+
+        use_cached_llm_results = self.global_config["eval"]["use_cached_llm_results"]
+        cache_path = f"{self.output_dir}/logs/text_extraction/text_extraction_eval_{inputs['case_id']}.json"
+        if use_cached_llm_results and os.path.exists(cache_path):
+            #page_texts = self.build_page_texts_from_log(Path(cache_path))
+            print(f"Skipping LLM call for case {inputs['case_id']} and using cached results from the logs.")
+        else:
+            output_page_text_translations = self._run_coro(
+                get_text_translation(
+                    self.prompt_config,
+                    page_text_list,
+                    self.base_language,
+                    self.target_language,
+                )
+            )
+
+            page_text_translations = [
+                page_text_translation.model_dump()
+                for page_text_translation in output_page_text_translations
+            ]
+
+        return {
+            "case_id": inputs["case_id"],
+            "step": inputs["step"],
+            "book_title": inputs["book_title"],
+            "page_number": inputs["page_number"],
+            "label_studio_url": (
+                f"https://{self.label_studio_config.host}/projects/{inputs['label_studio_project']}/data?task={inputs['case_id']}"
+            ),
+            "page_text_all": page_text_all,
+            "page_image_path": str(Path(page_image_path).relative_to(self.output_dir)),
+            "page_text_translations": page_text_translations,
+        }
+
+    def get_scorers(self) -> List[Any]:
+        return [is_acceptable_translation]
+
+    def get_report_results_and_metrics(self, eval_results):
+        result_df = eval_results.result_df.copy()
+        results: List[Dict[str, Any]] = []
+        for _, row in result_df.iterrows():
+            # inputs = row.get("request", {})
+            outputs = row.get("response", {})
+            assessments = row.get("assessments", {})
+            rationale = assessments[0].get("rationale", {})
+            matches = json.loads(rationale) if rationale else []
+            score = row.get("text_type_score/value") or 0
+
+            results.append(
+                {
+                    "id": outputs.get("case_id"),
+                    "book_title": outputs.get("book_title"),
+                    "page_number": outputs.get("page_number"),
+                    "label_studio_url": outputs.get("label_studio_url"),
+                    "page_text": outputs.get("page_text"),
+                    "page_image_path": outputs.get("page_image_path"),
+                    "page_texts": outputs.get("page_texts"),
+                    "score": score,
+                    "score_count": len(matches),
+                    "step": outputs.get("step"),
+                    "matches": matches,
+                }
+            )
+
+        metrics = {key.replace("/mean", ""): value for key, value in eval_results.metrics.items()}
+        metrics["score"] = metrics.get("text_type_score", 0.0)
+        return results, metrics

--- a/adt_eval/text_translation.py
+++ b/adt_eval/text_translation.py
@@ -8,11 +8,11 @@ Some notes on the scoring of matches:
     - For each line in the Gold Standard transcript, we seek a match and, if the line matches, one text type item is 'used up' from the list.
 """
 
-import os
 import ast
+import os
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List
-import traceback
 
 from banks import Prompt
 from litellm import completion
@@ -22,20 +22,14 @@ from mlflow.genai import scorer
 from adt_eval.mlflow_base import MLflowEvaluatorBase
 from adt_eval.utils.file import encode_image_to_base64, load_json, save_json
 from adt_eval.utils.text_translation import build_eval_translations, build_eval_translations_with_scores
-from adt_eval.utils.transcript_cleaner import normalize_transcript, standardize_transcript
-from adt_press.llm import get_instructor_client
 from adt_press.llm.text_translation import get_text_translation
-from adt_press.models.config import TextGroupType, TextType
 from adt_press.models.eval.text_translation import TranslationEvalOutputs
-from adt_press.models.pdf import Page
-from adt_press.models.text import PageTextGroups, Text, TextGroup
 from adt_press.utils.file import cached_read_text_file
 from adt_press.utils.languages import Language
 
 
 @scorer
 def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -> Feedback:
-    page_text_list = inputs.get("page_text_list", [])
     base_language = inputs.get("base_language", "en")
     target_language = inputs.get("target_language", "es")
     judge_cfg = (inputs.get("scorers") or {}).get("translation_acceptability") or {}
@@ -95,7 +89,7 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
         else:
             combined_rationale = "All translations are acceptable."
         
-    except Exception as e:
+    except Exception:
         print(f"Error evaluating translation: {traceback.format_exc()}")
         metric = 0
         combined_rationale = "Translation evaluation failed."

--- a/adt_eval/text_translation.py
+++ b/adt_eval/text_translation.py
@@ -12,235 +12,96 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict, List
+import traceback
 
+from banks import Prompt
+from litellm import completion
 from mlflow.entities import Feedback
 from mlflow.genai import scorer
-from litellm import completion
 
+from adt_eval.async_loop_context import get_current_loop_runner
 from adt_eval.mlflow_base import MLflowEvaluatorBase
+from adt_eval.utils.file import encode_image_to_base64
+from adt_eval.utils.text_translation import build_eval_translations
 from adt_eval.utils.transcript_cleaner import normalize_transcript, standardize_transcript
-from adt_press.utils.languages import Language
+from adt_press.llm import get_instructor_client
 from adt_press.llm.text_translation import get_text_translation
 from adt_press.models.config import TextGroupType, TextType
+from adt_press.models.eval.text_translation import TranslationEvalOutputs
 from adt_press.models.pdf import Page
 from adt_press.models.text import PageTextGroups, Text, TextGroup
-from adt_press.models.eval.text_translation import TranslationEvalOutputs
+from adt_press.utils.file import cached_read_text_file
 from adt_press.utils.languages import Language
-from adt_eval.utils.file import encode_image_to_base64
-
-TRANSLATION_SCORER_SYSTEM_PROMPT = """
-You are an expert multilingual translation evaluator specializing in children’s educational textbooks.
-You evaluate translations with a strict editorial standard suitable for K–12 instructional materials.
-
-Your task is NOT to translate. Your task is to STRICTLY JUDGE whether a translation is ACCEPTABLE or NOT ACCEPTABLE.
-
-You will be provided with:
-- input_language: the source language code.
-- input_text: the exact source text extracted from the textbook.
-- output_language: the target language code.
-- output_text: the model-generated translation.
-- page_image: an image of the textbook page (base64).
-
-Use the image ONLY to understand:
-- the role of the text (heading, label, instruction, paragraph, caption)
-- the subject matter (math, science, literacy, etc.)
-- the layout context (placement on page)
-
-If the image is unclear or partially visible, do not assume or invent anything.
-Your decision must be based primarily on input_text and output_text.
-
-----------------------------------------------------
-DEFINITION OF “ACCEPTABLE TRANSLATION”
-----------------------------------------------------
-A translation is ACCEPTABLE only if ALL conditions below are fully satisfied.
-If you are unsure whether an error is minor or major, treat it as major.
-
-### 1. ADEQUACY (meaning preservation — strict)
-- The translation preserves the complete meaning.
-- No omissions, distortions, additions, or reinterpretations.
-- All quantities, names, terminology, and logical relationships are correctly preserved.
-- No ambiguity introduced.
-
-### 2. FLUENCY & NATURALNESS (strict editorial standard)
-The target-language text must:
-- Be grammatically correct.
-- Use natural, idiomatic phrasing for children’s educational materials.
-- Sound like authentic textbook language for that language and grade level.
-- Avoid literal, machine-like, or awkward phrasing even if meaning is understandable.
-- Use appropriate stylistic form for headings, labels, and instructions.
-
-For ALL languages:
-If the translation sounds unnatural, unidiomatic, or does not resemble real textbook phrasing,
-→ NOT ACCEPTABLE.
-
-### 3. TERMINOLOGY & SUBJECT ACCURACY
-- Terminology must match grade-level norms for the target language.
-- Technical and academic concepts must remain correct.
-- No mistranslation that could cause misunderstanding of a concept.
-
-### 4. CONTEXTUAL APPROPRIATENESS (image-based)
-- Headings must read like headings.
-- Labels must read like labels.
-- Instructions must read like instructions.
-- The style and tone must fit children’s textbooks.
-
-----------------------------------------------------
-ADDITIONAL LANGUAGE-PAIR GUIDELINES (ENGLISH → SPANISH)
-----------------------------------------------------
-If input_language = "en" and output_language = "es", apply the following STRICT rules:
-
-### Spanish Textbook Fluency Rules
-Translations resembling any of the following patterns are NOT ACCEPTABLE:
-- Literal English calques (e.g., “NÚMEROS IMPACTANTES”, “PROBLEMAS DE HISTORIAS SOBRE...”)
-- Machine-like verb constructions
-- Unnatural noun constructions
-- Awkward or non-standard academic phrasing
-- Any phrasing not typically found in real Spanish K–12 textbooks
-
-The translation must sound like a native-authored Spanish textbook, not a direct conversion.
-
-### Non-acceptable Spanish Indicators
-If the Spanish includes unnatural literal phrasing, incorrect register, awkward expressions, or machine-like style,
-treat as major errors, even if meaning is technically understandable.
-
-----------------------------------------------------
-ERROR SEVERITY (STRICT INTERPRETATION)
-----------------------------------------------------
-
-### MAJOR ERRORS (→ ALWAYS NOT ACCEPTABLE)
-- Any mistranslation or incorrect meaning.
-- Any omitted or added content.
-- Incorrect or misleading terminology.
-- Any unnatural, awkward, or machine-like phrasing.
-- Any grammatical error.
-- Any mismatch with the text’s function (heading/label/etc.).
-- Any stylistic issue that would not pass editorial review.
-
-### MINOR ERRORS (rare, acceptable only if meaning + fluency + context are perfect)
-- Very small stylistic differences that do NOT affect idiomaticity, clarity, tone, or naturalness.
-- Harmless formatting differences.
-
-If unsure, classify the issue as major.
-
-----------------------------------------------------
-EVALUATION PROCESS (INTERNAL — DO NOT OUTPUT)
-----------------------------------------------------
-1. Assess adequacy.
-2. Assess fluency & naturalness with strict textbook standards.
-3. Assess terminology accuracy.
-4. Assess contextual appropriateness using the image.
-5. Apply strict error classification.
-6. Decide ACCEPTABLE vs NOT ACCEPTABLE.
-
-Do NOT reveal chain-of-thought.
-
-----------------------------------------------------
-OUTPUT FORMAT
-----------------------------------------------------
-Return ONLY the following JSON object:
-
-- is_translation_acceptable: boolean
-- rationale: short English explanation (1–3 sentences) summarizing the key reasons.
-
-Do NOT output anything else.
-"""
 
 
 @scorer
 def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -> Feedback:
 
     page_text_list = inputs.get("page_text_list", [])
-    source_language = inputs.get("base_language", "en")
+    base_language = inputs.get("base_language", "en")
     target_language = inputs.get("target_language", "es")
     page_text_translations = outputs.get("page_text_translations", [])
 
-    if isinstance(source_language, Language):
-        source_language = source_language.model_dump()
+    try:
 
-    if isinstance(target_language, Language):
+        # convert Language objects to dictionaries
+        base_language = base_language.model_dump()
         target_language = target_language.model_dump()
 
-    #get image  
-    image_path = inputs.get("image_path", "")
-    image_b64 = encode_image_to_base64(image_path)
+        # get image base64
+        image_path = inputs.get("image_path") or inputs.get("page_image_path") or ""
+        image_b64 = encode_image_to_base64(image_path)
 
-    #build eval_page_text_translations
-    eval_page_text_translations = []
-    for i, page_text_translation in enumerate(page_text_translations):
-        _, _, base_text = page_text_list[i]
-        translation_entry = {
-            "text_id": page_text_translation["text_id"],
-            "base_text": base_text,
-            "translation": page_text_translation["text"],
-        }
-        eval_page_text_translations.append(translation_entry)
-
-
-    if image_b64:
-        user_content = [
-            {
-                "type": "text",
-                "text": (
-                    "Evaluate whether the following Translation is ACCEPTABLE, "
-                    "using the criteria in the system prompt.\n\n"
-                    f"source_language: {source_language}\n"
-                    f"target_language: {target_language}\n"
-                    f"List of translations :\n\n{eval_page_text_translations}\n\n"
-                    "Below is the textbook page image in base64 format. "
-                    "Use it only to understand the context and how the text is used:\n"
-                ),
-            },
-            {
-                "type": "image_url",
-                "image_url": {
-                    "url": f"data:image/png;base64,{image_b64}"
-                },
-            },
-        ]
-    else:
-        user_content = (
-            "Evaluate whether the following Translation is ACCEPTABLE, "
-            "using the criteria in the system prompt.\n\n"
-            f"source_language: {source_language}\n"
-            f"target_language: {target_language}\n"
-            f"List of translations :\n\n{eval_page_text_translations}\n\n"
+        # build eval_page_text_translations
+        eval_page_text_translations = build_eval_translations(
+            page_text_list,
+            page_text_translations,
         )
 
-    messages = [
-        {"role": "system", "content": TRANSLATION_SCORER_SYSTEM_PROMPT},
-        {"role": "user", "content": user_content},
-    ]
+        #build context
+        context = dict(
+            base_language=base_language,
+            target_language=target_language,
+            eval_page_text_translations=eval_page_text_translations,
+            image_data_url=f"data:image/png;base64,{image_b64}" if image_b64 else None,
+        )
 
-    eval_output = completion(
-        model="gpt-5",
-        messages=messages,
-        response_format=TranslationEvalOutputs,
-    )
+        TRANSLATION_EVAL_PROMPT_PATH = "prompts/eval/text_translation_eval.jinja2" 
+        prompt = Prompt(cached_read_text_file(TRANSLATION_EVAL_PROMPT_PATH))
 
-    # Align with how you're handling other response_format=Pydantic calls
-    msg = eval_output.choices[0].message
-    translation_eval = TranslationEvalOutputs.model_validate_json(msg.content)
-    translation_output = translation_eval.model_dump()['outputs']
+        eval_output = completion(
+                model="gpt-5",
+                messages=[m.model_dump(exclude_none=True) for m in prompt.chat_messages(context)],
+                response_format=TranslationEvalOutputs,
+            )
 
-    #calculating the translation eval summary
-    summary_of_translations = [translation['is_translation_acceptable'] for translation in translation_output]
-    summary_of_failed_translations = [
-        {"text_id": translation["text_id"], "rationale": translation["rationale"]}
-        for translation in translation_output
-        if not translation["is_translation_acceptable"]
-    ]
+        msg = eval_output.choices[0].message
+        translation_eval = TranslationEvalOutputs.model_validate_json(msg.content)
+        translation_output = translation_eval.model_dump()["outputs"]
 
-    
-    #calculating the translation eval metric
-    metric= round(sum(summary_of_translations) / len(summary_of_translations), 2)
-    
-    #calculating the translation eval rationale
-    if summary_of_failed_translations:
-        combined_rationale = "The folowing translations are not acceptable:\n\n"
-        for entry in summary_of_failed_translations:
-            combined_rationale += f"- text_id: {entry['text_id']}\n  reason: {entry['rationale']}\n\n" 
-    else:
-        combined_rationale = "All translations are acceptable."
+        #calculating the translation eval summary
+        summary_of_translations = [translation['is_translation_acceptable'] for translation in translation_output]
+        summary_of_failed_translations = [
+            {"text_id": translation["text_id"], "rationale": translation["rationale"]}
+            for translation in translation_output
+            if not translation["is_translation_acceptable"]
+        ]
+
+        #calculating the translation eval metric
+        metric= round(sum(summary_of_translations) / len(summary_of_translations), 2)
+        
+        #calculating the combined translation eval rationale
+        if summary_of_failed_translations:
+            combined_rationale = "The folowing translations are not acceptable:\n\n"
+            for entry in summary_of_failed_translations:
+                combined_rationale += f"- text_id: {entry['text_id']}\n  reason: {entry['rationale']}\n\n" 
+        else:
+            combined_rationale = "All translations are acceptable."
+        
+    except Exception as e:
+        print(f"Error evaluating translation: {traceback.format_exc()}")
+        metric = 0
+        combined_rationale = "Translation evaluation failed."
     
     return Feedback(
         name="text_translation_score",
@@ -329,9 +190,9 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
         page_text_translations = []
 
         use_cached_llm_results = self.global_config["eval"]["use_cached_llm_results"]
-        cache_path = f"{self.output_dir}/logs/text_extraction/text_extraction_eval_{inputs['case_id']}.json"
+        cache_path = f"{self.output_dir}/logs/text_extraction/text_translation_eval_{inputs['case_id']}.json"
         if use_cached_llm_results and os.path.exists(cache_path):
-            #page_texts = self.build_page_texts_from_log(Path(cache_path))
+            #page_texts = self.build_page_texts_from_log(Path(cache_path)) #TODO: implement
             print(f"Skipping LLM call for case {inputs['case_id']} and using cached results from the logs.")
         else:
             output_page_text_translations = self._run_coro(

--- a/adt_eval/text_translation.py
+++ b/adt_eval/text_translation.py
@@ -8,8 +8,8 @@ Some notes on the scoring of matches:
     - For each line in the Gold Standard transcript, we seek a match and, if the line matches, one text type item is 'used up' from the list.
 """
 
-import json
 import os
+import ast
 from pathlib import Path
 from typing import Any, Dict, List
 import traceback
@@ -19,10 +19,9 @@ from litellm import completion
 from mlflow.entities import Feedback
 from mlflow.genai import scorer
 
-from adt_eval.async_loop_context import get_current_loop_runner
 from adt_eval.mlflow_base import MLflowEvaluatorBase
-from adt_eval.utils.file import encode_image_to_base64
-from adt_eval.utils.text_translation import build_eval_translations
+from adt_eval.utils.file import encode_image_to_base64, load_json, save_json
+from adt_eval.utils.text_translation import build_eval_translations, build_eval_translations_with_scores
 from adt_eval.utils.transcript_cleaner import normalize_transcript, standardize_transcript
 from adt_press.llm import get_instructor_client
 from adt_press.llm.text_translation import get_text_translation
@@ -36,14 +35,13 @@ from adt_press.utils.languages import Language
 
 @scorer
 def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -> Feedback:
-
     page_text_list = inputs.get("page_text_list", [])
     base_language = inputs.get("base_language", "en")
     target_language = inputs.get("target_language", "es")
-    page_text_translations = outputs.get("page_text_translations", [])
+    judge_cfg = (inputs.get("scorers") or {}).get("translation_acceptability") or {}
+    eval_page_text_translations = outputs.get("eval_page_text_translations", [])
 
     try:
-
         # convert Language objects to dictionaries
         base_language = base_language.model_dump()
         target_language = target_language.model_dump()
@@ -51,12 +49,6 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
         # get image base64
         image_path = inputs.get("image_path") or inputs.get("page_image_path") or ""
         image_b64 = encode_image_to_base64(image_path)
-
-        # build eval_page_text_translations
-        eval_page_text_translations = build_eval_translations(
-            page_text_list,
-            page_text_translations,
-        )
 
         #build context
         context = dict(
@@ -66,11 +58,11 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
             image_data_url=f"data:image/png;base64,{image_b64}" if image_b64 else None,
         )
 
-        TRANSLATION_EVAL_PROMPT_PATH = "prompts/eval/text_translation_eval.jinja2" 
-        prompt = Prompt(cached_read_text_file(TRANSLATION_EVAL_PROMPT_PATH))
+        prompt_path = judge_cfg.get("prompt_path") or "prompts/eval/text_translation_eval.jinja2"
+        prompt = Prompt(cached_read_text_file(prompt_path))
 
         eval_output = completion(
-                model="gpt-5",
+                model=judge_cfg.get("llm_as_judge_model") or "gpt-5",
                 messages=[m.model_dump(exclude_none=True) for m in prompt.chat_messages(context)],
                 response_format=TranslationEvalOutputs,
             )
@@ -81,6 +73,11 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
 
         #calculating the translation eval summary
         summary_of_translations = [translation['is_translation_acceptable'] for translation in translation_output]
+        summary_of_translations_metadata = [
+            {"text_id": translation["text_id"], 
+            "is_translation_acceptable": translation["is_translation_acceptable"],
+            "rationale": translation["rationale"]} 
+            for translation in translation_output]
         summary_of_failed_translations = [
             {"text_id": translation["text_id"], "rationale": translation["rationale"]}
             for translation in translation_output
@@ -107,6 +104,9 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
         name="text_translation_score",
         value=metric,
         rationale=combined_rationale,
+        metadata={
+            "summary_of_translations": summary_of_translations_metadata,
+        }
     )
 
 
@@ -118,24 +118,6 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
 
         self.base_language = Language.from_code(global_config.get("input_language", "en"))
         self.target_language = Language.from_code("es")
-
-    def build_page_texts_from_log(self, fpath: Path) -> PageTextGroups:
-        """Build PageTextGroups object from logged JSON file, as an alternative to LLM call."""
-        with open(fpath, "r", encoding="utf8") as f:
-            page_texts = json.load(f)
-            output = page_texts["output"]
-
-        page_text_groups = []
-        for g in output["groups"]:
-            page_texts = []
-            for t in g["texts"]:
-                page_text = Text(text_id=t["text_id"], text=t["text"], text_type=t["text_type"])
-                page_texts.append(page_text)
-            page_text_group = TextGroup(group_id=g["group_id"], group_type=g["group_type"], texts=page_texts)
-            page_text_groups.append(page_text_group)
-        page_texts = PageTextGroups(page_id=output["page_id"], groups=page_text_groups, reasoning=output["reasoning"])
-
-        return page_texts
 
     async def process_case(self, step: int, test_case: Dict[str, Any], use_cached_llm_results) -> Dict[str, Any]:
         """Legacy path: TextTypeEvaluator runs via mlflow.genai.evaluate."""
@@ -174,12 +156,11 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
                         "page_text_list": page_text_list,
                         "base_language": self.base_language,
                         "target_language": self.target_language,
+                        "scorers": self.task_config.get("scorers", {}),
                     },
                     "expectations": {},
                 }
             )
-
-        
         return records
 
     def predict_fn(self, **inputs: Any) -> Dict[str, Any]:
@@ -190,10 +171,10 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
         page_text_translations = []
 
         use_cached_llm_results = self.global_config["eval"]["use_cached_llm_results"]
-        cache_path = f"{self.output_dir}/logs/text_extraction/text_translation_eval_{inputs['case_id']}.json"
+        cache_path = f"{self.output_dir}/logs/text_translation/text_translation_eval_{inputs['case_id']}.json"
         if use_cached_llm_results and os.path.exists(cache_path):
-            #page_texts = self.build_page_texts_from_log(Path(cache_path)) #TODO: implement
             print(f"Skipping LLM call for case {inputs['case_id']} and using cached results from the logs.")
+            page_text_translations = load_json(cache_path)
         else:
             output_page_text_translations = self._run_coro(
                 get_text_translation(
@@ -208,6 +189,15 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
                 page_text_translation.model_dump()
                 for page_text_translation in output_page_text_translations
             ]
+            
+            #save to cache
+            save_json(cache_path, page_text_translations)
+
+        # build eval_page_text_translations
+        eval_page_text_translations = build_eval_translations(
+            page_text_list,
+            page_text_translations,
+        )
 
         return {
             "case_id": inputs["case_id"],
@@ -219,7 +209,7 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
             ),
             "page_text_all": page_text_all,
             "page_image_path": str(Path(page_image_path).relative_to(self.output_dir)),
-            "page_text_translations": page_text_translations,
+            "eval_page_text_translations": eval_page_text_translations
         }
 
     def get_scorers(self) -> List[Any]:
@@ -227,31 +217,34 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
 
     def get_report_results_and_metrics(self, eval_results):
         result_df = eval_results.result_df.copy()
-        results: List[Dict[str, Any]] = []
-        for _, row in result_df.iterrows():
-            # inputs = row.get("request", {})
-            outputs = row.get("response", {})
+        results = []
+        combined_is_translation_acceptable_results =[]
+        for index, row in result_df.iterrows():
+            output = row.get("response", {})
             assessments = row.get("assessments", {})
-            rationale = assessments[0].get("rationale", {})
-            matches = json.loads(rationale) if rationale else []
-            score = row.get("text_type_score/value") or 0
 
-            results.append(
-                {
-                    "id": outputs.get("case_id"),
-                    "book_title": outputs.get("book_title"),
-                    "page_number": outputs.get("page_number"),
-                    "label_studio_url": outputs.get("label_studio_url"),
-                    "page_text": outputs.get("page_text"),
-                    "page_image_path": outputs.get("page_image_path"),
-                    "page_texts": outputs.get("page_texts"),
-                    "score": score,
-                    "score_count": len(matches),
-                    "step": outputs.get("step"),
-                    "matches": matches,
-                }
+            page_text_scorer_scores_list = ast.literal_eval(assessments[0]['metadata']['summary_of_translations'])
+            eval_page_text_translations = output["eval_page_text_translations"]
+
+            eval_page_text_translations_with_scores = build_eval_translations_with_scores(
+                page_text_scorer_scores_list, 
+                eval_page_text_translations
             )
 
-        metrics = {key.replace("/mean", ""): value for key, value in eval_results.metrics.items()}
-        metrics["score"] = metrics.get("text_type_score", 0.0)
+            combined_is_translation_acceptable_results = combined_is_translation_acceptable_results + [t['is_translation_acceptable'] for t in page_text_scorer_scores_list]
+
+            results.append({
+                "id": output.get("case_id"),
+                'step': index + 1,
+                'page_number': output['page_number'],
+                'book_title': output['book_title'],
+                'page_text': output['page_text_all'],
+                'page_image_path': output['page_image_path'],
+                'score': assessments[0].get("feedback")['value'],
+                'translations': eval_page_text_translations_with_scores,
+            })
+
+        #get the metrics
+        metrics ={}
+        metrics["score"] = round(sum(combined_is_translation_acceptable_results)/len(combined_is_translation_acceptable_results), 2)
         return results, metrics

--- a/adt_eval/text_translation.py
+++ b/adt_eval/text_translation.py
@@ -44,7 +44,7 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
         image_path = inputs.get("image_path") or inputs.get("page_image_path") or ""
         image_b64 = encode_image_to_base64(image_path)
 
-        #build context
+        # build context
         context = dict(
             base_language=base_language,
             target_language=target_language,
@@ -56,51 +56,54 @@ def is_acceptable_translation(inputs: Dict[str, Any], outputs: Dict[str, Any]) -
         prompt = Prompt(cached_read_text_file(prompt_path))
 
         eval_output = completion(
-                model=judge_cfg.get("llm_as_judge_model") or "gpt-5",
-                messages=[m.model_dump(exclude_none=True) for m in prompt.chat_messages(context)],
-                response_format=TranslationEvalOutputs,
-            )
+            model=judge_cfg.get("llm_as_judge_model") or "gpt-5",
+            messages=[m.model_dump(exclude_none=True) for m in prompt.chat_messages(context)],
+            response_format=TranslationEvalOutputs,
+        )
 
         msg = eval_output.choices[0].message
         translation_eval = TranslationEvalOutputs.model_validate_json(msg.content)
         translation_output = translation_eval.model_dump()["outputs"]
 
-        #calculating the translation eval summary
-        summary_of_translations = [translation['is_translation_acceptable'] for translation in translation_output]
+        # calculating the translation eval summary
+        summary_of_translations = [translation["is_translation_acceptable"] for translation in translation_output]
         summary_of_translations_metadata = [
-            {"text_id": translation["text_id"], 
-            "is_translation_acceptable": translation["is_translation_acceptable"],
-            "rationale": translation["rationale"]} 
-            for translation in translation_output]
+            {
+                "text_id": translation["text_id"],
+                "is_translation_acceptable": translation["is_translation_acceptable"],
+                "rationale": translation["rationale"],
+            }
+            for translation in translation_output
+        ]
         summary_of_failed_translations = [
             {"text_id": translation["text_id"], "rationale": translation["rationale"]}
             for translation in translation_output
             if not translation["is_translation_acceptable"]
         ]
 
-        #calculating the translation eval metric
-        metric= round(sum(summary_of_translations) / len(summary_of_translations), 2)
-        
-        #calculating the combined translation eval rationale
+        # calculating the translation eval metric
+        metric = round(sum(summary_of_translations) / len(summary_of_translations), 2)
+
+        # calculating the combined translation eval rationale
         if summary_of_failed_translations:
             combined_rationale = "The folowing translations are not acceptable:\n\n"
             for entry in summary_of_failed_translations:
-                combined_rationale += f"- text_id: {entry['text_id']}\n  reason: {entry['rationale']}\n\n" 
+                combined_rationale += f"- text_id: {entry['text_id']}\n  reason: {entry['rationale']}\n\n"
         else:
             combined_rationale = "All translations are acceptable."
-        
+
     except Exception:
         print(f"Error evaluating translation: {traceback.format_exc()}")
         metric = 0
         combined_rationale = "Translation evaluation failed."
-    
+
     return Feedback(
         name="text_translation_score",
         value=metric,
         rationale=combined_rationale,
         metadata={
             "summary_of_translations": summary_of_translations_metadata,
-        }
+        },
     )
 
 
@@ -127,14 +130,9 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
                 test["page_image"],
                 f"text_extraction_page_{tc['id']}.png",
             )
-            
+
             page_text_list = [
-                (
-                    t["id"],
-                    t["value"]["taxonomy"][0][0] if t["value"].get("taxonomy") else "",
-                    t["value"]["text"]
-                )
-                for t in truth
+                (t["id"], t["value"]["taxonomy"][0][0] if t["value"].get("taxonomy") else "", t["value"]["text"]) for t in truth
             ]
 
             records.append(
@@ -161,7 +159,7 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
         page_text_all = inputs["page_text_all"]
         page_image_path = inputs["page_image_path"]
         page_text_list = inputs["page_text_list"]
-        
+
         page_text_translations = []
 
         use_cached_llm_results = self.global_config["eval"]["use_cached_llm_results"]
@@ -179,12 +177,9 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
                 )
             )
 
-            page_text_translations = [
-                page_text_translation.model_dump()
-                for page_text_translation in output_page_text_translations
-            ]
-            
-            #save to cache
+            page_text_translations = [page_text_translation.model_dump() for page_text_translation in output_page_text_translations]
+
+            # save to cache
             save_json(cache_path, page_text_translations)
 
         # build eval_page_text_translations
@@ -203,7 +198,7 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
             ),
             "page_text_all": page_text_all,
             "page_image_path": str(Path(page_image_path).relative_to(self.output_dir)),
-            "eval_page_text_translations": eval_page_text_translations
+            "eval_page_text_translations": eval_page_text_translations,
         }
 
     def get_scorers(self) -> List[Any]:
@@ -212,33 +207,36 @@ class TextTranslationEvaluator(MLflowEvaluatorBase):
     def get_report_results_and_metrics(self, eval_results):
         result_df = eval_results.result_df.copy()
         results = []
-        combined_is_translation_acceptable_results =[]
+        combined_is_translation_acceptable_results = []
         for index, row in result_df.iterrows():
             output = row.get("response", {})
             assessments = row.get("assessments", {})
 
-            page_text_scorer_scores_list = ast.literal_eval(assessments[0]['metadata']['summary_of_translations'])
+            page_text_scorer_scores_list = ast.literal_eval(assessments[0]["metadata"]["summary_of_translations"])
             eval_page_text_translations = output["eval_page_text_translations"]
 
             eval_page_text_translations_with_scores = build_eval_translations_with_scores(
-                page_text_scorer_scores_list, 
-                eval_page_text_translations
+                page_text_scorer_scores_list, eval_page_text_translations
             )
 
-            combined_is_translation_acceptable_results = combined_is_translation_acceptable_results + [t['is_translation_acceptable'] for t in page_text_scorer_scores_list]
+            combined_is_translation_acceptable_results = combined_is_translation_acceptable_results + [
+                t["is_translation_acceptable"] for t in page_text_scorer_scores_list
+            ]
 
-            results.append({
-                "id": output.get("case_id"),
-                'step': index + 1,
-                'page_number': output['page_number'],
-                'book_title': output['book_title'],
-                'page_text': output['page_text_all'],
-                'page_image_path': output['page_image_path'],
-                'score': assessments[0].get("feedback")['value'],
-                'translations': eval_page_text_translations_with_scores,
-            })
+            results.append(
+                {
+                    "id": output.get("case_id"),
+                    "step": index + 1,
+                    "page_number": output["page_number"],
+                    "book_title": output["book_title"],
+                    "page_text": output["page_text_all"],
+                    "page_image_path": output["page_image_path"],
+                    "score": assessments[0].get("feedback")["value"],
+                    "translations": eval_page_text_translations_with_scores,
+                }
+            )
 
-        #get the metrics
-        metrics ={}
-        metrics["score"] = round(sum(combined_is_translation_acceptable_results)/len(combined_is_translation_acceptable_results), 2)
+        # get the metrics
+        metrics = {}
+        metrics["score"] = round(sum(combined_is_translation_acceptable_results) / len(combined_is_translation_acceptable_results), 2)
         return results, metrics

--- a/adt_eval/utils/file.py
+++ b/adt_eval/utils/file.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from pathlib import Path
 
 def encode_image_to_base64(image_path: str | Path | None) -> str | None:
@@ -10,3 +11,14 @@ def encode_image_to_base64(image_path: str | Path | None) -> str | None:
             return base64.b64encode(f.read()).decode("utf-8")
     except Exception:
         return None
+
+def save_json(path: str | Path, data) -> None:
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("w", encoding="utf8") as f:
+        json.dump(data, f, ensure_ascii=True, indent=2)
+
+def load_json(path: str | Path):
+    file_path = Path(path)
+    with file_path.open("r", encoding="utf8") as f:
+        return json.load(f)

--- a/adt_eval/utils/file.py
+++ b/adt_eval/utils/file.py
@@ -1,0 +1,12 @@
+import base64
+from pathlib import Path
+
+def encode_image_to_base64(image_path: str | Path | None) -> str | None:
+    if not image_path:
+        return None
+    try:
+        path = Path(image_path)
+        with path.open("rb") as f:
+            return base64.b64encode(f.read()).decode("utf-8")
+    except Exception:
+        return None

--- a/adt_eval/utils/file.py
+++ b/adt_eval/utils/file.py
@@ -2,6 +2,7 @@ import base64
 import json
 from pathlib import Path
 
+
 def encode_image_to_base64(image_path: str | Path | None) -> str | None:
     if not image_path:
         return None

--- a/adt_eval/utils/file.py
+++ b/adt_eval/utils/file.py
@@ -13,11 +13,13 @@ def encode_image_to_base64(image_path: str | Path | None) -> str | None:
     except Exception:
         return None
 
+
 def save_json(path: str | Path, data) -> None:
     file_path = Path(path)
     file_path.parent.mkdir(parents=True, exist_ok=True)
     with file_path.open("w", encoding="utf8") as f:
         json.dump(data, f, ensure_ascii=True, indent=2)
+
 
 def load_json(path: str | Path):
     file_path = Path(path)

--- a/adt_eval/utils/text_translation.py
+++ b/adt_eval/utils/text_translation.py
@@ -22,12 +22,7 @@ def build_eval_translations(
             missing_ids.append(text_id)
             continue
         eval_items.append(
-            {
-                "text_id": text_id,
-                "base_text": base_text,
-                "translation": translation.get("text"),
-                "reasoning": translation.get("reasoning")
-            }
+            {"text_id": text_id, "base_text": base_text, "translation": translation.get("text"), "reasoning": translation.get("reasoning")}
         )
 
     if missing_ids:
@@ -35,6 +30,7 @@ def build_eval_translations(
         raise ValueError(f"Missing base text for text_id(s): {missing_ids_display}")
 
     return eval_items
+
 
 def build_eval_translations_with_scores(
     page_text_scorer_scores_list: List[Dict[str, Any]],
@@ -46,11 +42,11 @@ def build_eval_translations_with_scores(
 
         if not text_id:
             continue
-            
+
         for entry in page_text_scorer_scores_list:
             if entry.get("text_id") == text_id:
                 translation["is_translation_acceptable"] = entry.get("is_translation_acceptable")
                 translation["rationale"] = entry.get("rationale")
                 break
-            
+
     return page_text_translations

--- a/adt_eval/utils/text_translation.py
+++ b/adt_eval/utils/text_translation.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+def build_eval_translations(
+    page_text_list: Iterable[Tuple[str, str, str]],
+    page_text_translations: Iterable[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Join translations to base text by text_id.
+
+    Raises:
+        ValueError: If any translation text_id is missing from page_text_list.
+    """
+    base_text_by_id = {text_id: base_text for text_id, _text_type, base_text in page_text_list}
+
+    eval_items: List[Dict[str, Any]] = []
+    missing_ids: List[str] = []
+
+    for translation in page_text_translations:
+        text_id = translation.get("text_id")
+        base_text = base_text_by_id.get(text_id)
+        if base_text is None:
+            missing_ids.append(text_id)
+            continue
+        eval_items.append(
+            {
+                "text_id": text_id,
+                "base_text": base_text,
+                "translation": translation.get("text"),
+                "reasoning": translation.get("reasoning")
+            }
+        )
+
+    if missing_ids:
+        missing_ids_display = ", ".join(str(i) for i in missing_ids)
+        raise ValueError(f"Missing base text for text_id(s): {missing_ids_display}")
+
+    return eval_items
+
+def build_eval_translations_with_scores(
+    page_text_scorer_scores_list: List[Dict[str, Any]],
+    page_text_translations: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+
+    for translation in page_text_translations:
+        text_id = translation.get("text_id")
+
+        if not text_id:
+            continue
+            
+        for entry in page_text_scorer_scores_list:
+            if entry.get("text_id") == text_id:
+                translation["is_translation_acceptable"] = entry.get("is_translation_acceptable")
+                translation["rationale"] = entry.get("rationale")
+                break
+            
+    return page_text_translations

--- a/adt_press/models/eval/text_translation.py
+++ b/adt_press/models/eval/text_translation.py
@@ -10,6 +10,7 @@ class TranslationEvalOutput(BaseModel):
     is_translation_acceptable: bool
     rationale: str
 
+
 class TranslationEvalOutputs(BaseModel):
     base_language: str
     target_language: str

--- a/adt_press/models/eval/text_translation.py
+++ b/adt_press/models/eval/text_translation.py
@@ -1,5 +1,7 @@
-from typing import Any, Dict, List, Optional, Literal
-from pydantic import BaseModel, Field, ConfigDict, conint, confloat
+from typing import List
+
+from pydantic import BaseModel
+
 
 class TranslationEvalOutput(BaseModel):
     text_id: str

--- a/adt_press/models/eval/text_translation.py
+++ b/adt_press/models/eval/text_translation.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List, Optional, Literal
+from pydantic import BaseModel, Field, ConfigDict, conint, confloat
+
+class TranslationEvalOutput(BaseModel):
+    text_id: str
+    base_text: str
+    translation: str
+    is_translation_acceptable: bool
+    rationale: str
+
+class TranslationEvalOutputs(BaseModel):
+    base_language: str
+    target_language: str
+    outputs: List[TranslationEvalOutput]

--- a/config/eval_config.yaml
+++ b/config/eval_config.yaml
@@ -42,4 +42,4 @@ eval:
           prompt_path: prompts/eval/text_translation_eval.jinja2
   
   # Whether to use cached log files instead of calling the LLM (useful for debugging)
-  use_cached_llm_results: True
+  use_cached_llm_results: False

--- a/config/eval_config.yaml
+++ b/config/eval_config.yaml
@@ -27,6 +27,19 @@ eval:
       model: ${default_model}
       prompt: ${prompts.text_extraction}
       report_template_path: templates/eval/text_type_report.html
-
+      experiments_config:
+        experiment_name: "text_type"
+    text_translation:
+      label_studio_project_name: "A2: Text Type"
+      model: ${default_model}
+      prompt: ${prompts.text_translation}
+      report_template_path: templates/eval/text_translation_report.html
+      experiments_config:
+        experiment_name: "text-translation-dev-01"
+      scorers:
+        translation_acceptability:
+          llm_as_judge_model: gpt-5
+          prompt_path: prompts/eval/text_translation_eval.jinja2
+  
   # Whether to use cached log files instead of calling the LLM (useful for debugging)
-  use_cached_llm_results: False
+  use_cached_llm_results: True

--- a/prompts/eval/text_translation_eval.jinja2
+++ b/prompts/eval/text_translation_eval.jinja2
@@ -1,0 +1,134 @@
+{% chat role="system" %}
+You are an expert multilingual translation evaluator specializing in children’s educational textbooks.
+You evaluate translations with a strict editorial standard suitable for K–12 instructional materials.
+
+Your task is NOT to translate. Your task is to STRICTLY JUDGE whether a translation is ACCEPTABLE or NOT ACCEPTABLE.
+
+You will be provided with:
+- base_language: the source language name.
+- target_language: the target language name.
+- translations: a list of text entries containing base text and translation.
+- page_image: an image of the textbook page.
+
+Use the image ONLY to understand:
+- the role of the text (heading, label, instruction, paragraph, caption)
+- the subject matter (math, science, literacy, etc.)
+- the layout context (placement on page)
+
+If the image is unclear or partially visible, do not assume or invent anything.
+Your decision must be based primarily on base_text and translation.
+
+----------------------------------------------------
+DEFINITION OF “ACCEPTABLE TRANSLATION”
+----------------------------------------------------
+A translation is ACCEPTABLE only if ALL conditions below are fully satisfied.
+If you are unsure whether an error is minor or major, treat it as major.
+
+### 1. ADEQUACY (meaning preservation — strict)
+- The translation preserves the complete meaning.
+- No omissions, distortions, additions, or reinterpretations.
+- All quantities, names, terminology, and logical relationships are correctly preserved.
+- No ambiguity introduced.
+
+### 2. FLUENCY & NATURALNESS (strict editorial standard)
+The target-language text must:
+- Be grammatically correct.
+- Use natural, idiomatic phrasing for children’s educational materials.
+- Sound like authentic textbook language for that language and grade level.
+- Avoid literal, machine-like, or awkward phrasing even if meaning is understandable.
+- Use appropriate stylistic form for headings, labels, and instructions.
+
+For ALL languages:
+If the translation sounds unnatural, unidiomatic, or does not resemble real textbook phrasing,
+→ NOT ACCEPTABLE.
+
+### 3. TERMINOLOGY & SUBJECT ACCURACY
+- Terminology must match grade-level norms for the target language.
+- Technical and academic concepts must remain correct.
+- No mistranslation that could cause misunderstanding of a concept.
+
+### 4. CONTEXTUAL APPROPRIATENESS (image-based)
+- Headings must read like headings.
+- Labels must read like labels.
+- Instructions must read like instructions.
+- The style and tone must fit children’s textbooks.
+
+----------------------------------------------------
+ADDITIONAL LANGUAGE-PAIR GUIDELINES (ENGLISH → SPANISH)
+----------------------------------------------------
+If base_language is English and target_language is Spanish, apply the following STRICT rules:
+
+### Spanish Textbook Fluency Rules
+Translations resembling any of the following patterns are NOT ACCEPTABLE:
+- Literal English calques (e.g., “NÚMEROS IMPACTANTES”, “PROBLEMAS DE HISTORIAS SOBRE...”)
+- Machine-like verb constructions
+- Unnatural noun constructions
+- Awkward or non-standard academic phrasing
+- Any phrasing not typically found in real Spanish K–12 textbooks
+
+The translation must sound like a native-authored Spanish textbook, not a direct conversion.
+
+### Non-acceptable Spanish Indicators
+If the Spanish includes unnatural literal phrasing, incorrect register, awkward expressions, or machine-like style,
+treat as major errors, even if meaning is technically understandable.
+
+----------------------------------------------------
+ERROR SEVERITY (STRICT INTERPRETATION)
+----------------------------------------------------
+
+### MAJOR ERRORS (→ ALWAYS NOT ACCEPTABLE)
+- Any mistranslation or incorrect meaning.
+- Any omitted or added content.
+- Incorrect or misleading terminology.
+- Any unnatural, awkward, or machine-like phrasing.
+- Any grammatical error.
+- Any mismatch with the text’s function (heading/label/etc.).
+- Any stylistic issue that would not pass editorial review.
+
+### MINOR ERRORS (rare, acceptable only if meaning + fluency + context are perfect)
+- Very small stylistic differences that do NOT affect idiomaticity, clarity, tone, or naturalness.
+- Harmless formatting differences.
+
+If unsure, classify the issue as major.
+
+----------------------------------------------------
+EVALUATION PROCESS (INTERNAL — DO NOT OUTPUT)
+----------------------------------------------------
+1. Assess adequacy.
+2. Assess fluency & naturalness with strict textbook standards.
+3. Assess terminology accuracy.
+4. Assess contextual appropriateness using the image.
+5. Apply strict error classification.
+6. Decide ACCEPTABLE vs NOT ACCEPTABLE.
+
+Do NOT reveal chain-of-thought.
+
+----------------------------------------------------
+OUTPUT FORMAT
+----------------------------------------------------
+Return ONLY a JSON object that conforms to this schema:
+- base_language: string
+- target_language: string
+- outputs: list of
+  - text_id: string
+  - base_text: string
+  - translation: string
+  - is_translation_acceptable: boolean
+  - rationale: short English explanation (1–3 sentences) summarizing the key reasons
+
+Do NOT output anything else.
+{% endchat %}
+
+{% chat role="user" %}
+Evaluate whether the following translations are ACCEPTABLE, using the criteria in the system prompt.
+
+base_language: {{ base_language }}
+target_language: {{ target_language }}
+List of translations:
+{{ eval_page_text_translations }}
+
+{% if image_data_url %}
+Below is the textbook page image. Use it only to understand the context and how the text is used:
+{{ image_data_url | image }}
+{% endif %}
+{% endchat %}

--- a/templates/eval/base.html
+++ b/templates/eval/base.html
@@ -16,6 +16,7 @@
             <nav class="flex-1 p-4 overflow-y-auto">
                 <ul>
                     <li class="py-2"><a href="text_type_report.html" class="hover:text-gray-300">Text Type</a></li>
+                    <li class="py-2"><a href="text_translation_report.html" class="hover:text-gray-300">Text Translation</a></li>
                 </ul>
             </nav>
         </aside>

--- a/templates/eval/text_translation_report.html
+++ b/templates/eval/text_translation_report.html
@@ -1,0 +1,51 @@
+{% extends "eval/base.html" %}
+{% block title %}Translation Evaluation Report <span class="float-right ml-2 px-3 py-1 bg-blue-600 text-white text-sm font-medium rounded-full">{{ (score * 100) | round | int }}%</span>{% endblock %}
+
+{% block content %}
+{% for result in results %}
+    <div class="bg-white rounded border mb-6 overflow-hidden">
+        <!-- Page ID header -->
+        <div class="bg-gray-600 text-white px-4 py-3 font-bold text-xl flex justify-between items-center">
+            <span>Eval # {{result.step}} ({{ result.book_title }}, Page {{ result.page_number }})</span>
+            <div class="flex gap-2">
+                <span class="px-3 py-1 bg-gray-700 text-white text-sm font-medium rounded-full"><a href="{{ result.label_studio_url }}" target="_blank">{{ result.id }}</a></span>
+                <span class="px-3 py-1 bg-blue-600 text-white text-sm font-medium rounded-full">{{ (result.score * 100) | round | int}}%</span>
+            </div>
+        </div>
+        
+        <div class="flex gap-4 mb-6 pt-4 px-4">
+            <div class="flex-shrink-0">
+                <a href="{{ result.page_image_path }}" target="_blank" class="block">
+                    <img src="{{ result.page_image_path }}" class="h-auto max-h-[150px] border rounded shadow-sm hover:shadow-md transition-shadow" alt="Page {{ result.page_id }}">
+                </a>
+            </div>
+        </div>
+
+        <!-- Results header -->
+        <div class="bg-gray-700 text-white px-4 py-2 font-medium">
+            <div class="grid gap-4 px-2" style="grid-template-columns: 11fr 11fr 2fr;">
+                <div>Original Text</div>
+                <div>Translated Text</div>
+                <div class="px-2 text-center text-sm">Is Acceptable?</div>
+            </div>
+        </div>
+        
+        {% for translation in result.translations %}
+        <div class="grid gap-4 px-2 hover:bg-gray-50 items-center mx-4" style="grid-template-columns: 11fr 11fr 2fr;">
+            <div class="text-sm text-gray-700 py-1">{{ translation.base_text }}</div>
+            <div class="text-sm text-gray-700 py-1">{{ translation.translation }}</div>
+            <div class="text-center" title="{{ translation.rationale }}">
+                {% if translation.is_translation_acceptable %}
+                <span class="px-2 py-1 text-xs bg-green-100 text-green-800 rounded">YES</span>
+                {% else %}
+                <span class="px-2 py-1 text-xs bg-red-100 text-red-800 rounded">NO</span>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+        
+        <!-- Reasoning section -->
+    </div>
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
**What**  
- Add translation eval prompt and report template.
- Extend eval HTML base template for report layout.
- Implement translation eval utilities and file helpers.
- Wire translation eval flow into core eval modules.
- Update eval configuration to register the translation eval.

**Why**  
- Provide a dedicated text translation evaluation workflow with a standardized report output and configuration.

**How**  
- New Jinja prompt at `prompts/eval/text_translation_eval.jinja2`.
- New report template and updates to base template
- New eval utilities in and helper functions
- Integration changes in `adt_eval/text_translation.py`, `adt_eval/mlflow_base.py`, and `adt-eval.py`.
- Config update in `config/eval_config.yaml`.
